### PR TITLE
Add KL divergence computation for model evaluation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -2,12 +2,12 @@ import os
 import json
 import torch
 import logging
+import torch.nn.functional as F
 
 from tqdm import tqdm
 from torch import Tensor
 from jaxtyping import Float, Int
-from typing import List, Tuple
-import torch.nn.functional as F
+from typing import List, Tuple, Optional
 from datasets import load_dataset, Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -122,12 +122,166 @@ def run_inference(
     return outputs.logits, labels
 
 
-def save_metrics(perplexities: list, entropies: list, model_names: list) -> None:
+def save_base_logits(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    dataset: List[str],
+    batch_size: int = 32
+) -> None:
+    """
+    Save base model logits to disk batch by batch for memory efficiency.
+    """
+    base_logits_dir = "artefacts/base_logits"
+    os.makedirs(base_logits_dir, exist_ok=True)
+    
+    logger.info("Saving base model logits to disk...")
+    
+    batch_count = 0
+    for i in tqdm(range(0, len(dataset), batch_size), desc="Saving base logits"):
+        batch = dataset[i:i + batch_size]
+        logits, labels = run_inference(model, tokenizer, batch)
+        
+        # Save logits and labels for this batch
+        batch_data = {
+            'logits': logits.cpu(),  # Move to CPU for storage
+            'labels': labels.cpu()
+        }
+        
+        batch_file = os.path.join(base_logits_dir, f"batch_{batch_count}.pt")
+        torch.save(batch_data, batch_file)
+        batch_count += 1
+        
+        # Free GPU memory
+        del logits, labels
+    
+    # Save metadata
+    metadata = {
+        'batch_size': batch_size,
+        'total_batches': batch_count,
+        'dataset_size': len(dataset)
+    }
+    
+    with open(os.path.join(base_logits_dir, "metadata.json"), "w") as f:
+        json.dump(metadata, f, indent=4)
+    
+    logger.info(f"Saved {batch_count} batches of base logits to {base_logits_dir}")
+
+
+def load_base_logits_batch(batch_idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Load base model logits for a specific batch.
+    """
+    base_logits_dir = "artefacts/base_logits"
+    batch_file = os.path.join(base_logits_dir, f"batch_{batch_idx}.pt")
+    
+    if not os.path.exists(batch_file):
+        raise FileNotFoundError(f"Base logits batch {batch_idx} not found at {batch_file}")
+    
+    batch_data = torch.load(batch_file, map_location='cuda')
+    return batch_data['logits'].to('cuda'), batch_data['labels'].to('cuda')
+
+
+def compute_partial_kl_divergence(
+    base_logits: Float[Tensor, "batch seq_len vocab_size"],
+    checkpoint_logits: Float[Tensor, "batch seq_len vocab_size"], 
+    labels: Int[Tensor, "batch seq_len"]
+) -> float:
+    """
+    Compute partial KL divergence contribution for a batch.
+    KL(base || checkpoint) = sum(P * log(P/Q)) where P=base, Q=checkpoint
+    """
+    # Shift for causal language modeling
+    base_shift_logits = base_logits[:, :-1, :].contiguous()
+    checkpoint_shift_logits = checkpoint_logits[:, :-1, :].contiguous()
+    shift_labels = labels[:, 1:].contiguous()
+    
+    # Validity mask
+    valid_mask = (shift_labels != -100)
+    
+    # Convert to log probabilities for numerical stability
+    base_log_probs = F.log_softmax(base_shift_logits, dim=-1)
+    checkpoint_log_probs = F.log_softmax(checkpoint_shift_logits, dim=-1)
+    
+    # Convert base to probabilities
+    base_probs = torch.exp(base_log_probs)
+    
+    # Compute KL divergence: KL(P||Q) = sum(P * log(P/Q)) = sum(P * (log(P) - log(Q)))
+    kl_per_token = base_probs * (base_log_probs - checkpoint_log_probs)
+    kl_per_position = kl_per_token.sum(dim=-1)  # Sum over vocabulary
+    
+    # Apply validity mask and sum
+    masked_kl = kl_per_position * valid_mask.float()
+    sum_masked_kl = torch.sum(masked_kl).item()
+    
+    return sum_masked_kl
+
+
+def evaluate_with_kl_divergence(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    dataset: List[str],
+    batch_size: int = 32
+) -> Tuple[float, float, float]:
+    """
+    Evaluates perplexity, entropy, and KL divergence over the full dataset in batches.
+    """
+    if batch_size is None:
+        batch_size = len(dataset)
+    
+    total_sum_log_probs = 0.0
+    total_sum_entropy = 0.0
+    total_sum_kl = 0.0
+    total_valid = 0
+    
+    batch_idx = 0
+    for i in tqdm(range(0, len(dataset), batch_size), desc="Evaluating with KL"):
+        batch = dataset[i:i + batch_size]
+        
+        # Get checkpoint model logits
+        checkpoint_logits, labels = run_inference(model, tokenizer, batch)
+        
+        # Load corresponding base logits
+        base_logits, base_labels = load_base_logits_batch(batch_idx)
+        
+        # Compute standard metrics
+        sum_log_probs, sum_entropy, n_valid = compute_partial_metrics(checkpoint_logits, labels)
+        
+        # Compute KL divergence
+        sum_kl = compute_partial_kl_divergence(base_logits, checkpoint_logits, labels)
+        
+        # Accumulate
+        total_sum_log_probs += sum_log_probs
+        total_sum_entropy += sum_entropy
+        total_sum_kl += sum_kl
+        total_valid += n_valid
+        
+        # Free memory
+        del base_logits, checkpoint_logits, base_labels
+        
+        batch_idx += 1
+    
+    # Global averages
+    avg_nll = -total_sum_log_probs / total_valid
+    perplexity = torch.exp(torch.tensor(avg_nll)).item()
+    entropy = total_sum_entropy / total_valid
+    kl_divergence = total_sum_kl / total_valid
+    
+    logger.info(f"Full dataset: Perplexity {perplexity}, Entropy {entropy}, KL Divergence {kl_divergence}, Total valid tokens {total_valid}")
+    
+    return perplexity, entropy, kl_divergence
+
+
+def save_metrics(perplexities: list, entropies: list, kl_divergences: list, model_names: list) -> None:
     os.makedirs("artefacts", exist_ok=True)
     
     data = [
-        {"model_name": model_name, "perplexity": perplexity, "entropy": entropy}
-        for model_name, perplexity, entropy in zip(model_names, perplexities, entropies)
+        {
+            "model_name": model_name, 
+            "perplexity": perplexity, 
+            "entropy": entropy,
+            "kl_divergence": kl_divergence
+        }
+        for model_name, perplexity, entropy, kl_divergence in zip(model_names, perplexities, entropies, kl_divergences)
     ]
     
     with open("artefacts/metrics.json", "w") as f:


### PR DESCRIPTION
## Summary

This PR implements memory-efficient KL divergence computation to compare all checkpoint models against the base model (Qwen/Qwen2.5-0.5B-Instruct).

## Key Features

### Memory-Efficient Two-Pass Approach
- **First Pass**: Save base model logits to disk batch-by-batch
- **Second Pass**: Load base logits batch-by-batch while evaluating checkpoint models
- Maintains the same memory footprint as the original implementation

### New Functions Added

1. **`save_base_logits()`**: Stores base model logits to `artefacts/base_logits/` directory
2. **`load_base_logits_batch()`**: Loads specific batch of base logits from disk
3. **`compute_partial_kl_divergence()`**: Computes KL divergence for a single batch
4. **`evaluate_with_kl_divergence()`**: Combines perplexity, entropy, and KL computation

### Updated Functionality

- **`main.py`**: Now uses two-pass evaluation approach
- **`save_metrics()`**: Updated to include KL divergence values in JSON output
- **Metrics JSON**: Now includes `kl_divergence` field for each model

## Technical Details

- **KL Divergence Formula**: `KL(base || checkpoint) = sum(P * log(P/Q))` where P=base, Q=checkpoint
- **Numerical Stability**: Uses log-softmax and proper masking for valid tokens
- **Batch Processing**: Processes one batch at a time to maintain memory efficiency
- **Base Model**: KL divergence is 0.0 for the base model (comparing with itself)

## File Structure

```
artefacts/
├── base_logits/
│   ├── batch_0.pt
│   ├── batch_1.pt
│   ├── ...
│   └── metadata.json
└── metrics.json (now includes kl_divergence)
```

## Usage

The implementation maintains the same interface - just run:

```bash
python src/main.py
```

The output `metrics.json` will now include KL divergence values for all models.

## Testing

✅ Tested with small dataset subset  
✅ Verified KL divergence is ~0 for base model vs itself  
✅ Confirmed perplexity and entropy values remain unchanged  
✅ Memory usage stays within original constraints

@israel-adewuyi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a1228da1a85546efb32aee61a4b649b5)